### PR TITLE
Android : DateTools - Fix toIsoString

### DIFF
--- a/dependencies/hyp-system/src/hypsystem/system/DateTools.java
+++ b/dependencies/hyp-system/src/hypsystem/system/DateTools.java
@@ -20,6 +20,7 @@ import org.joda.time.format.ISODateTimeFormat;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 import org.joda.time.LocalTime;
+import org.joda.time.DateTimeZone;
 
 class DateTools
 {
@@ -96,13 +97,14 @@ class DateTools
 		}
 	}
 
-	public static String toISOString(float timestamp, boolean gmt)
+	public static String toISOString(float timestamp, boolean utc)
 	{
 		initializeJodaTime();
 
 		Date date = new Date((long)timestamp);
 
 		DateTime dateTime = new DateTime(date);
+		if (utc) dateTime = dateTime.withZone(DateTimeZone.UTC);
 		String ios = dateTime.toString(DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss'Z"));
 		return ios;
 	}

--- a/hypsystem/system/DateTools.hx
+++ b/hypsystem/system/DateTools.hx
@@ -58,9 +58,9 @@ class DateTools
 		return DateNative.toUTCString(getDateTime(date));
 	}
 
-	public static function toISOString(date:Date, ?gmt:Bool):String
+	public static function toISOString(date:Date, ?utc:Bool):String
 	{
-		return DateNative.toISOString(getDateTime(date), gmt);
+		return DateNative.toISOString(getDateTime(date), utc);
 	}
 
 	public static function fromISO(s:String):Date


### PR DESCRIPTION
- Rename the gmt optional parameter to `gmt`
- If true, use the `DateTimeZone.UTC` timezone for the `toISOString` resolution.