### PR TITLE
java source and target increase

### DIFF
--- a/dependencies/hyp-system/project.properties
+++ b/dependencies/hyp-system/project.properties
@@ -14,3 +14,6 @@ android.library.reference.2=../joda-time
 
 # Project target.
 target=android-::ANDROID_TARGET_SDK_VERSION::
+
+java.source=7
+java.target=7


### PR DESCRIPTION
There can be a better way to handle this issue. Without this change, project gives following error:

-compile:
    [javac] Compiling 8 source files to C:\myproject\bin\android\bin\deps\hypsystem\bin\classes
    [javac] warning: [options] source value 1.5 is obsolete and will be removed in a future release
    [javac] warning: [options] target value 1.5 is obsolete and will be removed in a future release
    [javac] warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
    [javac] C:\myproject\testproject\bin\android\bin\deps\hypsystem\src\hypsystem\net\NetworkInfos.java:110: error: multi-catch statement is not supported in -source 1.5
    [javac]                     catch (InterruptedException | ExecutionException | TimeoutException exception)
    [javac]                                                 ^
    [javac](use -source 7 or higher to enable multi-catch statement)
    [javac] 1 error
    [javac] 3 warnings
